### PR TITLE
Change vagrantBoxUrl to boxUrl

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ else
         end
 
         machineConfig.vm.provider :virtualbox do |vb,override|
-          override.vm.box_url = params['vagrantBoxUrl']
+          override.vm.box_url = params['boxUrl']
           override.vm.box = params['boxName']
           vb.customize ["modifyvm", :id, "--memory", chefNode['local-run']['memory']]
           vb.customize ["modifyvm", :id, "--cpus", chefNode['local-run']['cpus']]


### PR DESCRIPTION
Change vagrantBoxUrl to boxUrl because that it what the provisioning script provides.
Fix for https://github.com/Alfresco/alfresco-spk/issues/42